### PR TITLE
Semicolons in Unwrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,13 +656,13 @@ In place of common selectors like class, id or attribute we can use `document.qu
 
   // Native
   Array.prototype.forEach.call(document.querySelectorAll('.inner'), (el) => {
-    let elParentNode = el.parentNode
+    let elParentNode = el.parentNode;
 
     if(elParentNode !== document.body) {
-        elParentNode.parentNode.insertBefore(el, elParentNode)
-        elParentNode.parentNode.removeChild(elParentNode)
+        elParentNode.parentNode.insertBefore(el, elParentNode);
+        elParentNode.parentNode.removeChild(elParentNode);
     }
-  });
+  });   
   ```
 
 - [3.13](#3.13) <a name='3.13'></a> replaceWith


### PR DESCRIPTION
Added semicolons to the unwrap example. They're not strictly necessary, but this way there is consistency with other examples. Moreover, it's a good practice:

https://stackoverflow.com/questions/444080/do-you-recommend-using-semicolons-after-every-statement-in-javascript