### PR TITLE
Remove $.parseJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1174,19 +1174,7 @@ Most of jQuery utilities are also found in the native API. Other advanced functi
     return context.body.children;
   }
   ```
-
-  + parseJSON
-
-  Takes a well-formed JSON string and returns the resulting JavaScript value.
-
-  ```js
-  // jQuery
-  $.parseJSON(str);
-
-  // Native
-  JSON.parse(str);
-  ```
-
+      
 **[⬆ back to top](#table-of-contents)**
 
 ## Promises


### PR DESCRIPTION
$.parseJSON is officially deprecated in favor of the native implementation, so (if the page is intended to only have valid methods), I think it could just be removed:

http://api.jquery.com/jquery.parsejson/