### PR TITLE
fix some function of getNextSiblings/ isFunction/FadeIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,21 @@ In place of common selectors like class, id or attribute we can use `document.qu
     $el.nextAll($filter);
 
     // Native (optional filter function)
-    function getAllSiblings(elem, filter) {
-      var sibs = [];
-      elem = elem.parentNode.firstChild;
-      do {
-          if (elem.nodeType === 3) continue; // ignore text nodes
-          if (!filter || filter(elem)) sibs.push(elem);
-      } while (elem = elem.nextSibling)
-    return sibs;
-    }
+    function getNextSiblings(elem, filter) {
+            var sibs = [];
+            var nextElem = elem.parentNode.firstChild;
+            do {
+                if (nextElem.nodeType === 3) continue; // ignore text nodes
+                if (nextElem === elem) continue; // ignore elem of target
+                if (nextElem === elem.nextElementSibling) {
+                    if (!filter || filter(elem)) {
+                        sibs.push(nextElem);
+                        elem = nextElem;
+                    }
+                }
+            } while(nextElem = nextElem.nextSibling)
+            return sibs;
+        }
 
 An example of filter function:
 
@@ -927,7 +933,7 @@ Most of jQuery utilities are also found in the native API. Other advanced functi
     if (typeof item === 'function') {
       return true;
     }
-    var type = Object.prototype.toString(item);
+    var type = Object.prototype.toString.call(item);
     return type === '[object Function]' || type === '[object GeneratorFunction]';
   }
   ```
@@ -1327,7 +1333,7 @@ A promise represents the eventual result of an asynchronous operation. jQuery ha
     elem.style.opacity = 0;
 
     if (ms) {
-      const opacity = 0;
+      let opacity = 0;
       const timer = setInterval(function() {
         opacity += 50 / ms;
         if (opacity >= 1) {
@@ -1402,8 +1408,7 @@ A promise represents the eventual result of an asynchronous operation. jQuery ha
   const { height } = el.ownerDocument.defaultView.getComputedStyle(el, null);
   if (parseInt(height, 10) === 0) {
     el.style.height = originHeight;
-  }
-  else {
+  } else {
    el.style.height = '0px';
   }
   ```


### PR DESCRIPTION
Errors:
1. `getAllSiblings` return all siblings of target element, not return next siblings of target element
2. `Object.prototype.toString(item)` always return `[object Object]`
3. Use `const` to define a variable shouldn't change its value