### PR TITLE
null is faster than the \'\'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ An example of filter function:
   $el.empty();
 
   // Native
-  el.innerHTML = '';
+  el.innerHTML = null;
   ```
 
 - [3.11](#3.11) <a name='3.11'></a> wrap


### PR DESCRIPTION
null is faster than the \'\'.
When I calculated the performance time, I got a 30 ~ 60 % improvement.

[Processing result for very large resources]
innerHTML = '' - > 19sec
innerHTML = null - > 11sec