### PR TITLE
Native replaceWith and replaceChild for 3.13 replaceWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,12 +746,18 @@ function exampleFilter(elem) {
   // jQuery
   $('.inner').replaceWith('<div class="outer"></div>');
 
+  // Native (alternative) - latest, Edge17+
+  Array.from(document.querySelectorAll('.inner')).forEach((el) => {
+    const outer = document.createElement('div');
+    outer.className = 'outer';
+    el.replaceWith(outer);
+  });
+
   // Native
   Array.from(document.querySelectorAll('.inner')).forEach((el) => {
     const outer = document.createElement('div');
     outer.className = 'outer';
-    el.parentNode.insertBefore(outer, el);
-    el.parentNode.removeChild(el);
+    el.parentNode.replaceChild(outer, el);
   });
   ```
 


### PR DESCRIPTION
Makes the following changes:
- There's a pretty recent addition to the [living standard](https://dom.spec.whatwg.org/#interface-childnode) that defines `replaceWith`. Added an example of how to use it.
- Made the original example simpler by using `replaceChild` instead of `insertBefore` + `removeChild`.