### PR TITLE
Fix brackets and quotes

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -1297,9 +1297,9 @@ Una promesa, representa el resultado eventual de una operación asíncrona. jQue
 
   // Nativo
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 ## Alternativas

--- a/README-pl.md
+++ b/README-pl.md
@@ -1297,9 +1297,9 @@ Obietnice (_ang. Promises_) reprezentują ewentualny wynik asynchronicznej opera
 
   // Natywnie
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 ## Alternatywy

--- a/README-ru.md
+++ b/README-ru.md
@@ -1255,9 +1255,9 @@
 
   // Нативно
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -1458,9 +1458,9 @@ Promise는 비동기적인 작업의 결과를 표현합니다. jQuery는 자체
 
   // Native
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 ## 대안방법

--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ For a complete replacement with namespace and delegation, refer to https://githu
 
 - [5.2](#5.2) <a name='5.2'></a> Unbind an event with off
 
-```js
+  ```js
   // jQuery
   $el.off(eventName, eventHandler);
 
@@ -895,7 +895,7 @@ For a complete replacement with namespace and delegation, refer to https://githu
   }
 
   el.dispatchEvent(event);
-```
+  ```
 
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1482,9 +1482,9 @@ A promise represents the eventual result of an asynchronous operation. jQuery ha
 
   // Native
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 ## Alternatives

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1348,9 +1348,9 @@ Promise 代表异步操作的最终结果。jQuery 用它自己的方式处理 p
 
   // Native
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 **[⬆ 回到顶部](#目录)**

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1457,9 +1457,9 @@ promise 表示異步操作的最終結果。 jQuery 用它自己的方式來處�
 
   // Native
   el.style.transition = 'all ' + speed;
-  Object.keys(params).forEach((key) =>
+  Object.keys(params).forEach((key) => {
     el.style[key] = params[key];
-  )
+  });
   ```
 
 ## Alternatives


### PR DESCRIPTION
PR contains two fixes:
1. Brackets in js expression for `$el.animate` section
2. Layout slide in "Utilities" section because of wrong quotes positioning
<img width="813" alt="image" src="https://user-images.githubusercontent.com/13506547/169664460-02593f3d-fff6-49b6-afdd-f04b6571a427.png">
